### PR TITLE
Revert "chore(deps-dev): bump hugo-bin from 0.142.0 to 0.144.3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@knight-lab/timelinejs": "^3.9.7",
         "bundle-scss": "^1.5.4",
         "eslint": "^9.26.0",
-        "hugo-bin": "0.144.3",
+        "hugo-bin": "0.142.0",
         "live-server": "^1.2.2",
         "markdownlint-cli2": "^0.18.0",
         "neostandard": "^0.12.1",
@@ -5393,9 +5393,9 @@
       }
     },
     "node_modules/hugo-bin": {
-      "version": "0.144.3",
-      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.144.3.tgz",
-      "integrity": "sha512-bPGY9+IXGdVN6ibO2bnqjlXjUNlqg3D5p5FX3Wa/3dEnIkFYZfc10tvym0vOF3qouCa1TLOzEFTtFa/heE6Exw==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.142.0.tgz",
+      "integrity": "sha512-i3ar9xmBbeMf0Q5tXrkCM3fARWN8BWV99tOq+b63C7EZd7a0aD5SOzDAWGi0pGxy583oKc/tS0VQSS3QWUI0fA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@knight-lab/timelinejs": "^3.9.7",
     "bundle-scss": "^1.5.4",
     "eslint": "^9.26.0",
-    "hugo-bin": "0.144.3",
+    "hugo-bin": "0.142.0",
     "live-server": "^1.2.2",
     "markdownlint-cli2": "^0.18.0",
     "neostandard": "^0.12.1",


### PR DESCRIPTION
Reverts anoduck/hinode-testsite#111 due to incompatibility of hinode.