### PR TITLE
Remove neostandard dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "eslint": "^10.0.3",
     "hugo-bin": "0.149.2",
     "markdownlint-cli2": "^0.21.0",
-    "neostandard": "^0.13.0",
     "netlify-plugin-hugo-cache-resources": "^0.2.1",
     "npm-run-all": "^4.1.5",
     "postcss-cli": "^11.0.1",


### PR DESCRIPTION
Neostandard conflicts with newer eslint requirements, missing from upstream.